### PR TITLE
fix: specify the master branch when using git clone

### DIFF
--- a/scripts/docgen.sh
+++ b/scripts/docgen.sh
@@ -25,7 +25,7 @@ download_plugin() {
     folder="${tmp_rtp}/${2}"
     if [ ! -d $folder ]; then
         echo "Downloading '${repo}' into '${folder}..."
-        git clone --depth 1 ${repo} ${folder}
+        git clone -b master --depth 1 ${repo} ${folder}
     else
         echo "Updating '${repo}'..."
         git -C "${folder}" pull --rebase


### PR DESCRIPTION
:wave: I noticed that after nvim-treesitter [updated](https://github.com/nvim-treesitter/nvim-treesitter/commit/d3218d988f72ed34414959c9ccd802d393432d6e) the default branch to `main`, I began to get this error when running `docgen.sh`:

```txt
E5113: Lua chunk: ...ickfix-preview.nvim/deps/ts-vimdoc.nvim/scripts/init.lua:7: module 'nvim-treesitter.configs' not found:
        no field package.preload['nvim-treesitter.configs']
```

Updating the `git clone` to use `master` works well for me