### PR TITLE
fix: prevent netrw not found in packpath error

### DIFF
--- a/scripts/init.lua
+++ b/scripts/init.lua
@@ -1,3 +1,5 @@
+vim.g.loaded_netrw = 1
+vim.g.loaded_netrwPlugin = 1
 -- add temp path from scripts/docgen.sh in case this is running locally
 local tempdir = vim.trim(vim.fn.system('sh -c "dirname $(mktemp -u)"'))
 local packpath = os.getenv("PACKPATH") or tempdir .. "/ts-vimdoc.nvim.tmp/nvim/site"


### PR DESCRIPTION
:wave: When running `docgen.sh` I get this error/warning:
```
Error in /path/to/netrwPlugin.vim:
line    7:
E919: Directory not found in 'packpath': "pack/*/opt/netrw"
```
The script's exit code is `0` and the docs are generated just fine, but I find the error to be a bit noisy. Setting `loaded_netrw` and `loaded_netrwPlugin` to `1` removes the error, found in `:h netrw-noload`. Thoughts?